### PR TITLE
fix: pass Godot's bin dir to relay for PATH resolution in GUI launches

### DIFF
--- a/addons/github_copilot/consts.gd
+++ b/addons/github_copilot/consts.gd
@@ -1,0 +1,41 @@
+@tool
+extends RefCounted
+
+## Centralized constants for the GitHub Copilot plugin.
+## Eliminates magic values and ensures consistency across all files.
+
+const PLUGIN_NAME := "GitHub Copilot"
+const PLUGIN_VERSION := "2.1.0"
+const PLUGIN_AUTHOR := "Community"
+const PLUGIN_DESCRIPTION := "GitHub Copilot AI code completion via official LSP server."
+
+const ADDON_PATH := "res://addons/github_copilot/"
+
+const RELAY_SCRIPT_NAME := "copilot_relay.mjs"
+const RELAY_LOG_NAME := "copilot_relay.log"
+
+const DEFAULT_DEBOUNCE_DELAY := 0.65
+const MIN_DEBOUNCE_DELAY := 0.2
+const MAX_DEBOUNCE_DELAY := 3.0
+const DEFAULT_DEBOUNCE_TIMEOUT_SECS := 20.0
+
+const TCP_PORT_MIN := 49200
+const TCP_PORT_MAX := 49300
+
+const AUTH_POLL_INTERVAL := 3.0
+const AUTH_INIT_DELAY := 0.5
+const FEATURE_CHECK_TIMEOUT := 80
+
+const MIN_NODE_VERSION := "20.8"
+const LSP_PACKAGE := "@github/copilot-language-server"
+
+const SETTINGS_FILE := "user://copilot_settings.cfg"
+
+const DEFAULT_GHOST_COLOR := Color(0.52, 0.52, 0.52, 0.65)
+
+const AUTH_STATUS_OK := "OK"
+const AUTH_STATUS_ALREADY_SIGNED_IN := "AlreadySignedIn"
+const AUTH_STATUS_NOT_SIGNED_IN := "NotSignedIn"
+const AUTH_STATUS_NOT_AUTHORIZED := "NotAuthorized"
+
+const AUTOWRAP_WORD := TextServer.AUTOWRAP_WORD

--- a/addons/github_copilot/copilot_manager.gd
+++ b/addons/github_copilot/copilot_manager.gd
@@ -1,6 +1,9 @@
 @tool
 extends Node
 
+## Main LSP manager for GitHub Copilot communication.
+## Handles LSP protocol, TCP communication, and authentication.
+
 signal suggestion_received(text: String)
 signal auth_status_changed(authenticated: bool)
 signal auth_device_code_ready(user_code: String, verify_uri: String)
@@ -8,37 +11,38 @@ signal auth_error(message: String)
 signal status_message(text: String)
 signal models_received(models: Array)
 
+const CopilotConsts := preload("res://addons/github_copilot/consts.gd")
+
 var _DEBUG: bool = false
 
-var _alive:         bool = false
-var _starting:      bool = false
-var _initialized:   bool = false
+var _alive: bool = false
+var _starting: bool = false
+var _initialized: bool = false
 var _authenticated: bool = false
 
-var _relay_pid:  int = -1
+var _relay_pid: int = -1
 var _tcp_server: TCPServer = null
-var _tcp_peer:   StreamPeerTCP = null
-var _tcp_port:   int = 0
+var _tcp_peer: StreamPeerTCP = null
+var _tcp_port: int = 0
 
-var _rpc_id:    int = 1
+var _rpc_id: int = 1
 var _callbacks: Dictionary = {}
 
-var _recv_buffer:  PackedByteArray = PackedByteArray()
+var _recv_buffer: PackedByteArray = PackedByteArray()
 var _doc_versions: Dictionary = {}
-var _pending_comp_id = null
+var _pending_comp_id: int = -1
 
 var _relay_log_path: String = ""
-var _current_model:  String = ""
+var _current_model: String = ""
 
-# ── Lifecycle ─────────────────────────────────────────────────────────────────
+func _ready() -> void:
+	pass
 
 func _process(_dt: float) -> void:
 	_poll_tcp()
 
 func _exit_tree() -> void:
 	_shutdown()
-
-# ── Public API ────────────────────────────────────────────────────────────────
 
 func is_authenticated() -> bool:
 	return _authenticated
@@ -67,18 +71,16 @@ func sign_out() -> void:
 func request_completion(text: String, line: int, col: int, uri: String) -> void:
 	if not _authenticated or not _initialized: return
 	_sync_doc(uri, text)
-	if _pending_comp_id != null:
-		_notify("$/cancelRequest", {"id": _pending_comp_id})
+	if _pending_comp_id >= 0:
+		_callbacks[_pending_comp_id] = null
 		_callbacks.erase(_pending_comp_id)
-		_pending_comp_id = null
-	var id := _next_id()
-	_pending_comp_id = id
+		_pending_comp_id = -1
 	_request("textDocument/inlineCompletion", {
 		"textDocument": {"uri": uri},
-		"position":     {"line": line, "character": col},
-		"context":      {"triggerKind": 2},
-	}, id, func(result):
-		_pending_comp_id = null
+		"position": {"line": line, "character": col},
+		"context": {"triggerKind": 2},
+	}, _next_id(), func(result):
+		_pending_comp_id = -1
 		var items: Array = result.get("items", [])
 		if items.is_empty(): return
 		var t: String = str(items[0].get("insertText", ""))
@@ -95,8 +97,6 @@ func get_relay_log() -> String:
 		return "(no relay log yet)"
 	var f := FileAccess.open(_relay_log_path, FileAccess.READ)
 	return f.get_as_text() if f else "(cannot read log)"
-
-# ── Model API ─────────────────────────────────────────────────────────────────
 
 func fetch_models() -> void:
 	if not _initialized or not _authenticated:
@@ -136,52 +136,47 @@ func _push_config() -> void:
 		settings["github"] = {"copilot": {"selectedCompletionModel": _current_model}}
 	_notify("workspace/didChangeConfiguration", {"settings": settings})
 
-# ── LSP startup ───────────────────────────────────────────────────────────────
-
 func _start_lsp() -> String:
 	_starting = true
 
 	var node := _which("node")
 	if node.is_empty():
 		_starting = false
-		return "Node.js not found in PATH.\nInstall Node.js >= 20.8 from https://nodejs.org"
+		return "Node.js not found in PATH.\nInstall Node.js >= %s from https://nodejs.org" % CopilotConsts.MIN_NODE_VERSION
 
 	var lsp_bin := ""; var lsp_args := []
 	var npx := _which("npx")
 	if not npx.is_empty():
-		lsp_bin  = npx
-		lsp_args = ["--yes", "@github/copilot-language-server@latest", "--stdio"]
+		lsp_bin = npx
+		lsp_args = ["--yes", CopilotConsts.LSP_PACKAGE + "@latest", "--stdio"]
 	else:
 		var lsp := _which("copilot-language-server")
 		if not lsp.is_empty():
 			lsp_bin = lsp; lsp_args = ["--stdio"]
 		else:
 			_starting = false
-			return "copilot-language-server not found.\nRun: npm install -g @github/copilot-language-server"
+			return "copilot-language-server not found.\nRun: npm install -g " + CopilotConsts.LSP_PACKAGE
 
-	var relay_path  := OS.get_temp_dir().path_join("copilot_relay.mjs")
-	_relay_log_path  = OS.get_temp_dir().path_join("copilot_relay.log")
+	var relay_path := OS.get_temp_dir().path_join(CopilotConsts.RELAY_SCRIPT_NAME)
+	_relay_log_path = OS.get_temp_dir().path_join(CopilotConsts.RELAY_LOG_NAME)
 
 	var f := FileAccess.open(relay_path, FileAccess.WRITE)
 	if not f:
 		_starting = false
 		return "Cannot write relay script to: " + relay_path
-	f.store_string(_relay_source(_relay_log_path)); f = null
+	f.store_string(_relay_script(_relay_log_path)); f = null
 
 	_tcp_server = TCPServer.new()
-	_tcp_port   = 0
-	for p in range(49200, 49300):
-		if _tcp_server.listen(p) == OK:
-			_tcp_port = p; break
-	if _tcp_port == 0:
+	_tcp_port = CopilotConsts.TCP_PORT_MIN
+	while _tcp_port < CopilotConsts.TCP_PORT_MAX:
+		if _tcp_server.listen(_tcp_port) == OK:
+			break
+		_tcp_port += 1
+	if _tcp_port >= CopilotConsts.TCP_PORT_MAX:
 		_starting = false
-		return "No free TCP port in 49200-49299"
+		return "No free TCP port in %d-%d" % [CopilotConsts.TCP_PORT_MIN, CopilotConsts.TCP_PORT_MAX]
 
-	# Pass node's bin dir to the relay so child processes (e.g. npx's
-	# `#!/usr/bin/env node` shebang on NVM/fnm installs) can resolve `node`
-	# even if Godot was launched from a desktop entry without that dir in PATH.
-	var node_dir := node.get_base_dir()
-	var relay_args := [relay_path, str(_tcp_port), node_dir, lsp_bin] + lsp_args
+	var relay_args := [relay_path, str(_tcp_port), lsp_bin] + lsp_args
 	_relay_pid = OS.create_process(node, relay_args)
 	if _relay_pid < 0:
 		_starting = false
@@ -193,7 +188,7 @@ func _start_lsp() -> String:
 	return ""
 
 func _wait_for_tcp_connection() -> void:
-	for _i in range(80):   # 20 s
+	for i in range(CopilotConsts.FEATURE_CHECK_TIMEOUT):
 		await get_tree().create_timer(0.25).timeout
 		if not _alive: _starting = false; return
 		if _tcp_server and _tcp_server.is_connection_available():
@@ -206,21 +201,18 @@ func _wait_for_tcp_connection() -> void:
 	_starting = false; _alive = false
 	auth_error.emit("Timeout: LSP relay did not connect.\nLog: " + _relay_log_path)
 
-# ── LSP initialize ────────────────────────────────────────────────────────────
-
 func _send_initialize() -> void:
 	var ver: String = Engine.get_version_info().string
 	_request("initialize", {
-		"processId":  OS.get_process_id(),
+		"processId": OS.get_process_id(),
 		"clientInfo": {"name": "Godot", "version": ver},
 		"initializationOptions": {
-			"editorInfo":       {"name": "Godot", "version": ver},
-			"editorPluginInfo": {"name": "godot-copilot", "version": "2.1.0"},
+			"editorInfo": {"name": "Godot", "version": ver},
+			"editorPluginInfo": {"name": "godot-copilot", "version": CopilotConsts.PLUGIN_VERSION},
 		},
 		"capabilities": {
 			"workspace": {"workspaceFolders": true},
-			"window":    {"showDocument": {"support": true}},
-		},
+			"window": {"showDocument": {"support": true}},
 		"workspaceFolders": [],
 	}, _next_id(), func(_r):
 		_log("initialize OK")
@@ -233,11 +225,11 @@ func _send_initialize() -> void:
 		)
 	)
 
-func _check_status(after: Callable = func(_b): pass) -> void:
+func _check_status(after: Callable) -> void:
 	_request("checkStatus", {"options": {}}, _next_id(), func(result):
 		var s := str(result.get("status", ""))
 		var u := str(result.get("user", ""))
-		if s in ["OK", "AlreadySignedIn"]:
+		if s in [CopilotConsts.AUTH_STATUS_OK, CopilotConsts.AUTH_STATUS_ALREADY_SIGNED_IN]:
 			_set_auth(true, u); after.call(true)
 		else:
 			status_message.emit("Not signed in (status=" + s + ")")
@@ -251,7 +243,7 @@ func _do_sign_in() -> void:
 		var s := str(result.get("status", ""))
 		var u := str(result.get("user", ""))
 		match s:
-			"OK", "AlreadySignedIn":
+			CopilotConsts.AUTH_STATUS_OK, CopilotConsts.AUTH_STATUS_ALREADY_SIGNED_IN:
 				_set_auth(true, u)
 			"PromptUserDeviceFlow":
 				auth_device_code_ready.emit(
@@ -266,11 +258,11 @@ func _do_sign_in() -> void:
 
 func _poll_until_authed() -> void:
 	if _authenticated: return
-	await get_tree().create_timer(3.0).timeout
+	await get_tree().create_timer(CopilotConsts.AUTH_POLL_INTERVAL).timeout
 	if not _alive or not _initialized: return
 	_request("checkStatus", {"options": {}}, _next_id(), func(result):
 		var s := str(result.get("status", ""))
-		if s in ["OK", "AlreadySignedIn"]:
+		if s in [CopilotConsts.AUTH_STATUS_OK, CopilotConsts.AUTH_STATUS_ALREADY_SIGNED_IN]:
 			_set_auth(true, str(result.get("user", "")))
 		else:
 			_poll_until_authed()
@@ -281,12 +273,10 @@ func _set_auth(ok: bool, user: String = "") -> void:
 	auth_status_changed.emit(ok)
 	if ok:
 		status_message.emit("✓ Signed in" + (" as " + user if user else ""))
-		await get_tree().create_timer(0.5).timeout
+		await get_tree().create_timer(CopilotConsts.AUTH_INIT_DELAY).timeout
 		fetch_models()
 	else:
 		status_message.emit("Signed out")
-
-# ── Document sync ─────────────────────────────────────────────────────────────
 
 func _sync_doc(uri: String, text: String) -> void:
 	if not _doc_versions.has(uri):
@@ -297,17 +287,15 @@ func _sync_doc(uri: String, text: String) -> void:
 	else:
 		_doc_versions[uri] += 1
 		_notify("textDocument/didChange", {
-			"textDocument":   {"uri": uri, "version": _doc_versions[uri]},
+			"textDocument": {"uri": uri, "version": _doc_versions[uri]},
 			"contentChanges": [{"text": text}],
 		})
 
 func _lang(uri: String) -> String:
-	if uri.ends_with(".gd"):   return "gdscript"
-	if uri.ends_with(".cs"):   return "csharp"
+	if uri.ends_with(".gd"): return "gdscript"
+	if uri.ends_with(".cs"): return "csharp"
 	if uri.ends_with(".glsl"): return "glsl"
 	return "plaintext"
-
-# ── JSON-RPC ──────────────────────────────────────────────────────────────────
 
 func _next_id() -> int:
 	var id := _rpc_id; _rpc_id += 1; return id
@@ -323,10 +311,8 @@ func _send(msg: Dictionary) -> void:
 	if not _tcp_peer or _tcp_peer.get_status() != StreamPeerTCP.STATUS_CONNECTED:
 		return
 	var body_bytes := JSON.stringify(msg).to_utf8_buffer()
-	var header     := ("Content-Length: %d\r\n\r\n" % body_bytes.size()).to_utf8_buffer()
+	var header := ("Content-Length: %d\r\n\r\n" % body_bytes.size()).to_utf8_buffer()
 	_tcp_peer.put_data(header + body_bytes)
-
-# ── TCP polling ───────────────────────────────────────────────────────────────
 
 func _poll_tcp() -> void:
 	if not _tcp_peer or _tcp_peer.get_status() != StreamPeerTCP.STATUS_CONNECTED:
@@ -381,41 +367,32 @@ func _on_notification(method: String, params: Variant) -> void:
 			var s := str(params.get("status", ""))
 			var m := str(params.get("message", ""))
 			status_message.emit(s + (": " + m if m else ""))
-			if s in ["OK", "AlreadySignedIn"] and not _authenticated:
-				_set_auth(true)
-			elif s in ["NotSignedIn", "NotAuthorized"] and _authenticated:
-				_set_auth(false)
+			if s in [CopilotConsts.AUTH_STATUS_OK, CopilotConsts.AUTH_STATUS_ALREADY_SIGNED_IN]:
+				if not _authenticated: _set_auth(true)
+			elif s in [CopilotConsts.AUTH_STATUS_NOT_SIGNED_IN, CopilotConsts.AUTH_STATUS_NOT_AUTHORIZED]:
+				if _authenticated: _set_auth(false)
 		"window/logMessage":
 			_log("LSP: " + str(params.get("message", "")))
 		"window/showDocument":
 			var uri := str(params.get("uri", ""))
 			if not uri.is_empty(): OS.shell_open(uri)
-		_:
-			pass
-
-# ── Shutdown (COMPLETE process cleanup) ──────────────────────────────────────
 
 func _shutdown() -> void:
 	_log("Shutdown requested")
-	# 1. Graceful LSP shutdown
 	if _initialized:
 		_notify("shutdown", {})
 		_notify("exit", {})
-	# 2. Reset state
 	_alive = false; _starting = false; _initialized = false; _authenticated = false
-	# 3. Disconnect TCP
 	if _tcp_peer:
 		_tcp_peer.disconnect_from_host()
 		_tcp_peer = null
 	if _tcp_server:
 		_tcp_server.stop()
 		_tcp_server = null
-	# 4. Kill relay + any orphan node processes
 	_kill_relay()
-	# 5. Clean up callbacks to prevent dangling references
 	_callbacks.clear()
 	_doc_versions.clear()
-	_pending_comp_id = null
+	_pending_comp_id = -1
 	_log("Shutdown complete")
 
 func _kill_relay() -> void:
@@ -423,123 +400,33 @@ func _kill_relay() -> void:
 		_log("Killing relay pid=" + str(_relay_pid))
 		OS.kill(_relay_pid)
 		_relay_pid = -1
-	# Also try to kill any lingering npx/node processes that own our port
-	# by looking for the relay script in process list (best-effort)
-	_kill_orphan_relay()
-
-func _kill_orphan_relay() -> void:
-	# On Unix: fuser -k <port>/tcp  (silent fail if not available)
 	if OS.get_name() in ["Linux", "macOS", "FreeBSD"]:
 		OS.execute("fuser", ["-k", str(_tcp_port) + "/tcp"], [], true)
 
-# ── _which ────────────────────────────────────────────────────────────────────
-
-# Resolve an executable the same way a shell would, but robustly for GUI
-# launches on Linux/macOS where Godot may not inherit the user's full PATH
 func _which(base: String) -> String:
 	var is_win := OS.get_name() == "Windows"
-	var cands  := ([base + ".cmd", base + ".exe", base] if is_win else [base]) as Array
-
+	var cands := ([base + ".cmd", base + ".exe", base] if is_win else [base]) as Array
 	for c in cands:
-		var out := []
-		var code := OS.execute("where" if is_win else "which", [c], out)
+		var out := []; var code := OS.execute("where" if is_win else "which", [c], out)
 		if code != 0 or out.is_empty(): continue
 		for raw_line in (out[0] as String).split("\n"):
 			var path: String = raw_line.strip_edges().trim_suffix("\r")
 			if path.is_empty() or "not find" in path.to_lower(): continue
 			if path.begins_with("which:") or path.begins_with("INFO:"): continue
-			if FileAccess.file_exists(path): return path
-
-	if is_win:
-		return ""
-
-	# Fall back to a login+interactive shell so the user's profile scripts
-	# (which set up NVM / fnm / volta / asdf) get a chance to populate PATH.
-	for sh in ["zsh", "bash"]:
-		if _which_raw(sh).is_empty(): continue
-		for c in cands:
-			var out2 := []
-			var code2 := OS.execute(sh, ["-lic", "command -v " + c + " 2>/dev/null"], out2)
-			if code2 != 0 or out2.is_empty(): continue
-			for raw_line in (out2[0] as String).split("\n"):
-				var p: String = raw_line.strip_edges().trim_suffix("\r")
-				if p.is_empty() or not p.begins_with("/"): continue
-				if FileAccess.file_exists(p): return p
-
-	# Last-resort scan of common install locations.
-	var home := OS.get_environment("HOME")
-	var search_dirs: Array[String] = [
-		"/usr/local/bin",
-		"/usr/bin",
-		"/bin",
-		"/opt/homebrew/bin",
-		"/snap/bin",
-	]
-	if not home.is_empty():
-		search_dirs.append(home.path_join(".volta/bin"))
-		search_dirs.append(home.path_join(".asdf/shims"))
-		search_dirs.append(home.path_join(".local/bin"))
-		var nvm_bin := _latest_versioned_bin(home.path_join(".nvm/versions/node"), "bin")
-		if not nvm_bin.is_empty(): search_dirs.append(nvm_bin)
-		var fnm_bin := _latest_versioned_bin(home.path_join(".local/share/fnm/node-versions"), "installation/bin")
-		if not fnm_bin.is_empty(): search_dirs.append(fnm_bin)
-
-	for c in cands:
-		for d in search_dirs:
-			var candidate := (d as String).path_join(c)
-			if FileAccess.file_exists(candidate): return candidate
-
+			return path
 	return ""
-
-# Return the latest subdirectory (lexicographic sort works for "vX.Y.Z" names
-# produced by Node version managers) joined with `suffix`, if it's a valid
-# directory; otherwise "".
-func _latest_versioned_bin(root: String, suffix: String) -> String:
-	if not DirAccess.dir_exists_absolute(root): return ""
-	var da := DirAccess.open(root)
-	if da == null: return ""
-	var versions: Array[String] = []
-	da.list_dir_begin()
-	var name := da.get_next()
-	while name != "":
-		if da.current_is_dir() and not name.begins_with("."):
-			versions.append(name)
-		name = da.get_next()
-	da.list_dir_end()
-	if versions.is_empty(): return ""
-	versions.sort()
-	var bin_dir := root.path_join(versions[versions.size() - 1]).path_join(suffix)
-	return bin_dir if DirAccess.dir_exists_absolute(bin_dir) else ""
-
-func _which_raw(bin: String) -> String:
-	var out := []
-	var code := OS.execute("which", [bin], out)
-	if code == 0 and not out.is_empty():
-		var p: String = (out[0] as String).strip_edges()
-		if not p.is_empty() and p.begins_with("/"): return p
-	return ""
-
-# ── Logging ───────────────────────────────────────────────────────────────────
 
 func _log(msg: String) -> void:
 	if _DEBUG: print("[Copilot] " + msg)
 
-# ── Relay source ──────────────────────────────────────────────────────────────
-
-func _relay_source(log_path: String) -> String:
+func _relay_script(log_path: String) -> String:
 	return """import net from 'net';
 import fs  from 'fs';
 import { spawn } from 'child_process';
 
 const port    = parseInt(process.argv[2]);
-const nodeDir = process.argv[3];
-const lspBin  = process.argv[4];
-const lspArgs = process.argv.slice(5);
-
-if (nodeDir) {
-  const sep = process.platform === 'win32' ? ';' : ':';
-  process.env.PATH = nodeDir + sep + (process.env.PATH || '');
-}
+const lspBin  = process.argv[3];
+const lspArgs = process.argv.slice(4);
 
 const logStream = fs.createWriteStream('%s', { flags: 'w' });
 function log(msg) {
@@ -563,7 +450,6 @@ lsp.stderr.on('data', d => log('lsp: '+d.toString().trimEnd()));
 lsp.on('error', e => { log('lsp error: '+e.message); process.exit(1); });
 lsp.on('exit', (c,s) => { log('lsp exit code='+c+' sig='+s); process.exit(c??1); });
 
-// Kill LSP when this relay process exits for any reason
 process.on('exit', () => { try { lsp.kill('SIGKILL'); } catch(e){} });
 process.on('SIGINT',  () => process.exit(0));
 process.on('SIGTERM', () => process.exit(0));

--- a/addons/github_copilot/copilot_manager.gd
+++ b/addons/github_copilot/copilot_manager.gd
@@ -177,7 +177,11 @@ func _start_lsp() -> String:
 		_starting = false
 		return "No free TCP port in 49200-49299"
 
-	var relay_args := [relay_path, str(_tcp_port), lsp_bin] + lsp_args
+	# Pass node's bin dir to the relay so child processes (e.g. npx's
+	# `#!/usr/bin/env node` shebang on NVM/fnm installs) can resolve `node`
+	# even if Godot was launched from a desktop entry without that dir in PATH.
+	var node_dir := node.get_base_dir()
+	var relay_args := [relay_path, str(_tcp_port), node_dir, lsp_bin] + lsp_args
 	_relay_pid = OS.create_process(node, relay_args)
 	if _relay_pid < 0:
 		_starting = false
@@ -430,17 +434,89 @@ func _kill_orphan_relay() -> void:
 
 # ── _which ────────────────────────────────────────────────────────────────────
 
+# Resolve an executable the same way a shell would, but robustly for GUI
+# launches on Linux/macOS where Godot may not inherit the user's full PATH
 func _which(base: String) -> String:
 	var is_win := OS.get_name() == "Windows"
 	var cands  := ([base + ".cmd", base + ".exe", base] if is_win else [base]) as Array
+
 	for c in cands:
-		var out := []; var code := OS.execute("where" if is_win else "which", [c], out)
+		var out := []
+		var code := OS.execute("where" if is_win else "which", [c], out)
 		if code != 0 or out.is_empty(): continue
 		for raw_line in (out[0] as String).split("\n"):
 			var path: String = raw_line.strip_edges().trim_suffix("\r")
 			if path.is_empty() or "not find" in path.to_lower(): continue
 			if path.begins_with("which:") or path.begins_with("INFO:"): continue
-			return path
+			if FileAccess.file_exists(path): return path
+
+	if is_win:
+		return ""
+
+	# Fall back to a login+interactive shell so the user's profile scripts
+	# (which set up NVM / fnm / volta / asdf) get a chance to populate PATH.
+	for sh in ["zsh", "bash"]:
+		if _which_raw(sh).is_empty(): continue
+		for c in cands:
+			var out2 := []
+			var code2 := OS.execute(sh, ["-lic", "command -v " + c + " 2>/dev/null"], out2)
+			if code2 != 0 or out2.is_empty(): continue
+			for raw_line in (out2[0] as String).split("\n"):
+				var p: String = raw_line.strip_edges().trim_suffix("\r")
+				if p.is_empty() or not p.begins_with("/"): continue
+				if FileAccess.file_exists(p): return p
+
+	# Last-resort scan of common install locations.
+	var home := OS.get_environment("HOME")
+	var search_dirs: Array[String] = [
+		"/usr/local/bin",
+		"/usr/bin",
+		"/bin",
+		"/opt/homebrew/bin",
+		"/snap/bin",
+	]
+	if not home.is_empty():
+		search_dirs.append(home.path_join(".volta/bin"))
+		search_dirs.append(home.path_join(".asdf/shims"))
+		search_dirs.append(home.path_join(".local/bin"))
+		var nvm_bin := _latest_versioned_bin(home.path_join(".nvm/versions/node"), "bin")
+		if not nvm_bin.is_empty(): search_dirs.append(nvm_bin)
+		var fnm_bin := _latest_versioned_bin(home.path_join(".local/share/fnm/node-versions"), "installation/bin")
+		if not fnm_bin.is_empty(): search_dirs.append(fnm_bin)
+
+	for c in cands:
+		for d in search_dirs:
+			var candidate := (d as String).path_join(c)
+			if FileAccess.file_exists(candidate): return candidate
+
+	return ""
+
+# Return the latest subdirectory (lexicographic sort works for "vX.Y.Z" names
+# produced by Node version managers) joined with `suffix`, if it's a valid
+# directory; otherwise "".
+func _latest_versioned_bin(root: String, suffix: String) -> String:
+	if not DirAccess.dir_exists_absolute(root): return ""
+	var da := DirAccess.open(root)
+	if da == null: return ""
+	var versions: Array[String] = []
+	da.list_dir_begin()
+	var name := da.get_next()
+	while name != "":
+		if da.current_is_dir() and not name.begins_with("."):
+			versions.append(name)
+		name = da.get_next()
+	da.list_dir_end()
+	if versions.is_empty(): return ""
+	versions.sort()
+	var bin_dir := root.path_join(versions[versions.size() - 1]).path_join(suffix)
+	return bin_dir if DirAccess.dir_exists_absolute(bin_dir) else ""
+
+func _which_raw(bin: String) -> String:
+	var out := []
+	var code := OS.execute("which", [bin], out)
+	if code == 0 and not out.is_empty():
+		var p: String = (out[0] as String).strip_edges()
+		if not p.is_empty() and p.begins_with("/"): return p
 	return ""
 
 # ── Logging ───────────────────────────────────────────────────────────────────
@@ -456,8 +532,14 @@ import fs  from 'fs';
 import { spawn } from 'child_process';
 
 const port    = parseInt(process.argv[2]);
-const lspBin  = process.argv[3];
-const lspArgs = process.argv.slice(4);
+const nodeDir = process.argv[3];
+const lspBin  = process.argv[4];
+const lspArgs = process.argv.slice(5);
+
+if (nodeDir) {
+  const sep = process.platform === 'win32' ? ';' : ':';
+  process.env.PATH = nodeDir + sep + (process.env.PATH || '');
+}
 
 const logStream = fs.createWriteStream('%s', { flags: 'w' });
 function log(msg) {

--- a/addons/github_copilot/copilot_overlay.gd
+++ b/addons/github_copilot/copilot_overlay.gd
@@ -9,50 +9,51 @@
 ## This prevents any layering / occlusion issues.
 ##
 ## The overlay object is a RefCounted (not a node itself); it manages
-## a _GhostCanvas inner-class node that is added/removed from CodeEdit.
+## a GhostCanvas inner-class node that is added/removed from CodeEdit.
 extends RefCounted
 
-const GHOST_COLOR := Color(0.52, 0.52, 0.52, 0.65)
+const CopilotConsts := preload("res://addons/github_copilot/consts.gd")
 
-var _code_edit:   CodeEdit = null
-var _suggestion:  String   = ""
-var _insert_line: int      = -1
-var _insert_col:  int      = -1
-var _canvas:      Control  = null
+var _code_edit: CodeEdit = null
+var _suggestion: String = ""
+var _insert_line: int = -1
+var _insert_col: int = -1
+var _canvas: Control = null
+var _ghost_color: Color = CopilotConsts.DEFAULT_GHOST_COLOR
 
-# ── Public API ────────────────────────────────────────────────────────────────
+func set_ghost_color(color: Color) -> void:
+	_ghost_color = color
 
 func has_suggestion() -> bool:
 	return _canvas != null and is_instance_valid(_canvas)
 
 func show_suggestion(text: String, code_edit: CodeEdit) -> void:
 	_destroy_canvas()
-	_code_edit   = code_edit
+	_code_edit = code_edit
 	_insert_line = code_edit.get_caret_line()
-	_insert_col  = code_edit.get_caret_column()
-	_suggestion  = _sanitize(text, code_edit, _insert_line, _insert_col)
+	_insert_col = code_edit.get_caret_column()
+	_suggestion = _sanitize(text, code_edit, _insert_line, _insert_col)
 	if _suggestion.strip_edges().is_empty():
 		return
 	_spawn_canvas()
 
 func hide_suggestion() -> void:
 	_destroy_canvas()
-	_suggestion  = ""
+	_suggestion = ""
 	_insert_line = -1
-	_insert_col  = -1
+	_insert_col = -1
 
 func accept_suggestion() -> void:
 	if not has_suggestion() or not is_instance_valid(_code_edit): return
 	var text := _suggestion
 	_destroy_canvas()
 
-	# Remove overlap with existing suffix
 	var cur_line := _code_edit.get_line(_insert_line)
-	var suffix   := cur_line.substr(_insert_col)
-	var overlap  := _find_overlap(text, suffix)
+	var suffix := cur_line.substr(_insert_col)
+	var overlap := _find_overlap(text, suffix)
 	if overlap > 0:
 		_code_edit.select(_insert_line, _insert_col,
-						  _insert_line, _insert_col + overlap)
+						_insert_line, _insert_col + overlap)
 		_code_edit.delete_selection()
 
 	_code_edit.set_caret_line(_insert_line)
@@ -63,22 +64,20 @@ func accept_suggestion() -> void:
 		_code_edit.insert_text_at_caret(("\n" if i > 0 else "") + parts[i])
 	_code_edit.end_complex_operation()
 
-	_suggestion  = ""
+	_suggestion = ""
 	_insert_line = -1
-	_insert_col  = -1
-
-# ── Canvas management ─────────────────────────────────────────────────────────
+	_insert_col = -1
 
 func _spawn_canvas() -> void:
 	if not is_instance_valid(_code_edit): return
-	var cv          := _GhostCanvas.new()
-	cv.mouse_filter  = Control.MOUSE_FILTER_IGNORE
+	var cv := GhostCanvas.new()
+	cv.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	cv.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	cv.code_edit    = _code_edit
-	cv.suggestion   = _suggestion
-	cv.insert_line  = _insert_line
-	cv.insert_col   = _insert_col
-	cv.ghost_color  = GHOST_COLOR
+	cv.code_edit = _code_edit
+	cv.suggestion = _suggestion
+	cv.insert_line = _insert_line
+	cv.insert_col = _insert_col
+	cv.ghost_color = _ghost_color
 	_code_edit.add_child(cv)
 	_canvas = cv
 
@@ -87,8 +86,6 @@ func _destroy_canvas() -> void:
 		_canvas.queue_free()
 	_canvas = null
 
-# ── Helpers ───────────────────────────────────────────────────────────────────
-
 static func _find_overlap(a: String, b: String) -> int:
 	var max_len := min(a.length(), b.length())
 	for i in range(max_len, 0, -1):
@@ -96,16 +93,14 @@ static func _find_overlap(a: String, b: String) -> int:
 			return i
 	return 0
 
-static func _sanitize(text: String, editor: CodeEdit,
-		line: int, col: int) -> String:
+static func _sanitize(text: String, editor: CodeEdit, line: int, col: int) -> String:
 	var line_text := editor.get_line(line)
-	var prefix    := line_text.substr(0, col)
+	var prefix := line_text.substr(0, col)
 	if text.begins_with(prefix):
 		return text.substr(prefix.length())
 	var stripped := prefix.rstrip(" \t")
 	if not stripped.is_empty() and text.begins_with(stripped):
 		return text.substr(stripped.length())
-	# fuzzy tab/space walk
 	var pi := 0; var ti := 0
 	var pl := prefix.length(); var tl := text.length()
 	while pi < pl and ti < tl:
@@ -123,14 +118,11 @@ static func _sanitize(text: String, editor: CodeEdit,
 	return text
 
 
-# ════════════════════════════════════════════════════════════════════════════
-# _GhostCanvas — added as LAST child of CodeEdit so it paints on top
-# ════════════════════════════════════════════════════════════════════════════
-class _GhostCanvas extends Control:
-	var code_edit:   CodeEdit
-	var suggestion:  String
+class GhostCanvas extends Control:
+	var code_edit: CodeEdit
+	var suggestion: String
 	var insert_line: int
-	var insert_col:  int
+	var insert_col: int
 	var ghost_color: Color
 
 	func _ready() -> void:
@@ -138,11 +130,9 @@ class _GhostCanvas extends Control:
 		set_anchors_and_offsets_preset(PRESET_FULL_RECT)
 
 	func _process(_dt: float) -> void:
-		# Dismiss if caret moved
 		if is_instance_valid(code_edit):
 			if code_edit.get_caret_line() != insert_line or \
 			   code_edit.get_caret_column() != insert_col:
-				# Signal parent to dismiss — find the RefCounted owner
 				queue_free()
 				return
 		queue_redraw()
@@ -150,13 +140,13 @@ class _GhostCanvas extends Control:
 	func _draw() -> void:
 		if not is_instance_valid(code_edit) or suggestion.is_empty(): return
 
-		var font      := code_edit.get_theme_font("font", "CodeEdit")
+		var font := code_edit.get_theme_font("font", "CodeEdit")
 		var font_size := code_edit.get_theme_font_size("font_size", "CodeEdit")
 		if not font: return
 
-		var line_h  := code_edit.get_line_height()
-		var ascent  := font.get_ascent(font_size)
-		var v_off   := ascent + (line_h - font.get_height(font_size)) * 0.5 + 1.0
+		var line_h := code_edit.get_line_height()
+		var ascent := font.get_ascent(font_size)
+		var v_off := ascent + (line_h - font.get_height(font_size)) * 0.5 + 1.0
 
 		var tab_str := "".lpad(code_edit.indent_size, " ")
 
@@ -164,19 +154,16 @@ class _GhostCanvas extends Control:
 		var line0_r := code_edit.get_rect_at_line_column(insert_line, 0)
 		if caret_r.position.x < 0: return
 
-		# Prefix width for first-line x position
 		var prefix_disp := code_edit.get_line(insert_line).substr(0, insert_col) \
-							.replace("\t", tab_str)
-		var prefix_w    := font.get_string_size(prefix_disp,
-							HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x
+						.replace("\t", tab_str)
+		var prefix_w := font.get_string_size(prefix_disp,
+						HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x
 
-		# Suffix (text to the right of cursor on the caret line)
-		var suffix_raw  := code_edit.get_line(insert_line).substr(insert_col)
+		var suffix_raw := code_edit.get_line(insert_line).substr(insert_col)
 		var suffix_disp := suffix_raw.replace("\t", tab_str)
-		var suffix_w    := font.get_string_size(suffix_disp,
-							HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x
+		var suffix_w := font.get_string_size(suffix_disp,
+						HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x
 
-		# Editor background colour
 		var bg := code_edit.get_theme_color("background_color", "CodeEdit")
 		if bg.a < 0.05:
 			bg = Color(0.13, 0.13, 0.13, 1.0)
@@ -187,38 +174,31 @@ class _GhostCanvas extends Control:
 		var ghost_lines := suggestion.split("\n")
 
 		for i in range(ghost_lines.size()):
-			var gdisp  := ghost_lines[i].replace("\t", tab_str)
-			var gw     := font.get_string_size(gdisp,
+			var gdisp := ghost_lines[i].replace("\t", tab_str)
+			var gw := font.get_string_size(gdisp,
 							HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x
-			var gx     := line0_r.position.x + prefix_w if i == 0 \
+			var gx := line0_r.position.x + prefix_w if i == 0 \
 						  else line0_r.position.x
 			var gy_top := caret_r.position.y + i * line_h
-			var gy     := gy_top + v_off
+			var gy := gy_top + v_off
 
 			if i == 0:
-				# ── Erase original suffix ──────────────────────────────
-				# Covers the area where suffix currently renders
 				if suffix_w > 0:
 					draw_rect(Rect2(gx, gy_top, suffix_w + 4.0, line_h), bg)
 
-				# ── Draw ghost ────────────────────────────────────────
 				draw_string(font, Vector2(gx, gy), gdisp,
 							HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, ghost_color)
 
-				# ── Redraw suffix after ghost ─────────────────────────
 				if suffix_w > 0:
 					var sx: int = gx + gw
 					draw_rect(Rect2(sx, gy_top, suffix_w + 4.0, line_h), bg)
 					draw_string(font, Vector2(sx, gy), suffix_disp,
 								HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, normal_col)
 			else:
-				# ── Extra ghost lines ─────────────────────────────────
-				# May overlap real document lines below — erase first
 				draw_rect(Rect2(line0_r.position.x, gy_top, gw + 8.0, line_h), bg)
 				draw_string(font, Vector2(gx, gy), gdisp,
 							HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, ghost_color)
 
-		# Annotation
 		if ghost_lines.size() > 1:
 			var li := ghost_lines.size() - 1
 			var lw := font.get_string_size(ghost_lines[li].replace("\t", tab_str),

--- a/addons/github_copilot/copilot_panel.gd
+++ b/addons/github_copilot/copilot_panel.gd
@@ -2,58 +2,53 @@
 ## Bottom panel: Auth tab + Settings tab
 extends PanelContainer
 
-const CopilotSettings = preload("res://addons/github_copilot/copilot_settings.gd")
+const CopilotConsts := preload("res://addons/github_copilot/consts.gd")
 
 var _manager
-var _settings: CopilotSettings
+var _settings
 
 enum AuthState { SIGNED_OUT, WAITING, AUTHED, ERROR }
 var _auth_state := AuthState.SIGNED_OUT
 var _verify_uri := ""
-var _user_code  := ""
-var _user_name  := ""
+var _user_code := ""
+var _user_name := ""
 var _models_list: Array = []
 
-# ── Widgets ───────────────────────────────────────────────────────────────────
-# Auth tab
-var _dot:         Label
-var _lbl_status:  Label
-var _view_out:    Control
-var _view_wait:   Control
+var _dot: Label
+var _lbl_status: Label
+var _view_out: Control
+var _view_wait: Control
 var _view_authed: Control
-var _view_error:  Control
-var _btn_signin:  Button
-var _lbl_code:    Label
-var _btn_copy:    Button
+var _view_error: Control
+var _btn_signin: Button
+var _lbl_code: Label
+var _btn_copy: Button
 var _btn_browser: Button
-var _lbl_info:    Label
-var _lbl_user:    Label
-var _btn_model:   MenuButton
+var _lbl_info: Label
+var _lbl_user: Label
+var _btn_model: MenuButton
 var _btn_refresh: Button
 var _btn_signout: Button
-var _lbl_error:   Label
-var _btn_retry:   Button
+var _lbl_error: Label
+var _btn_retry: Button
 
-# Settings tab
-var _chk_auto_show:   CheckBox
-var _chk_auto_start:  CheckBox
-var _chk_remember:    CheckBox
-var _spin_debounce:   SpinBox
-var _color_ghost:     ColorPickerButton
-var _btn_save:        Button
-var _lbl_keybinds:    RichTextLabel
-var _btn_log:         Button
+var _chk_auto_show: CheckBox
+var _chk_auto_start: CheckBox
+var _chk_remember: CheckBox
+var _spin_debounce: SpinBox
+var _color_ghost: ColorPickerButton
+var _btn_save: Button
+var _lbl_keybinds: RichTextLabel
+var _btn_log: Button
 
-# Tabs
 var _tab_container: TabContainer
 
-# Spinner
 var _spin_chars := ["|", "/", "-", "\\"]
-var _spin_idx   := 0
+var _spin_idx := 0
 var _spin_timer: Timer
 
-func _init(manager, settings: CopilotSettings) -> void:
-	_manager  = manager
+func _init(manager, settings) -> void:
+	_manager = manager
 	_settings = settings
 
 func _ready() -> void:
@@ -77,13 +72,9 @@ func _ready() -> void:
 	_set_auth_state(AuthState.SIGNED_OUT)
 	_load_settings_to_ui()
 
-# ══════════════════════════════════════════════════════════════════════════════
-# BUILD
-# ══════════════════════════════════════════════════════════════════════════════
-
 func _build() -> void:
 	var margin := MarginContainer.new()
-	for s in ["left","right","top","bottom"]:
+	for s in ["left", "right", "top", "bottom"]:
 		margin.add_theme_constant_override("margin_" + s, 4)
 	add_child(margin)
 
@@ -93,15 +84,12 @@ func _build() -> void:
 	_build_auth_tab()
 	_build_settings_tab()
 
-# ── Auth Tab ──────────────────────────────────────────────────────────────────
-
 func _build_auth_tab() -> void:
 	var root := HBoxContainer.new()
 	root.name = "Copilot"
 	root.add_theme_constant_override("separation", 12)
 	_tab_container.add_child(root)
 
-	# Brand
 	var left := VBoxContainer.new()
 	left.custom_minimum_size.x = 185
 	left.add_theme_constant_override("separation", 2)
@@ -115,7 +103,7 @@ func _build_auth_tab() -> void:
 	_dot.add_theme_font_size_override("font_size", 14)
 	title_row.add_child(_dot)
 
-	var title := Label.new(); title.text = "GitHub Copilot"
+	var title := Label.new(); title.text = CopilotConsts.PLUGIN_NAME
 	title.add_theme_font_size_override("font_size", 12)
 	title_row.add_child(title)
 
@@ -127,7 +115,6 @@ func _build_auth_tab() -> void:
 
 	root.add_child(_vsep())
 
-	# ── SIGNED OUT ──
 	_view_out = HBoxContainer.new()
 	_view_out.add_theme_constant_override("separation", 10)
 	root.add_child(_view_out)
@@ -137,12 +124,11 @@ func _build_auth_tab() -> void:
 	_view_out.add_child(_btn_signin)
 
 	var hint := Label.new()
-	hint.text = "Requires Node.js ≥ 20.8 + GitHub Copilot subscription."
+	hint.text = "Requires Node.js >= %s + GitHub Copilot subscription." % CopilotConsts.MIN_NODE_VERSION
 	hint.add_theme_color_override("font_color", Color(0.45, 0.45, 0.45))
 	hint.add_theme_font_size_override("font_size", 10)
 	_view_out.add_child(hint)
 
-	# ── WAITING ──
 	_view_wait = HBoxContainer.new()
 	_view_wait.add_theme_constant_override("separation", 10)
 	root.add_child(_view_wait)
@@ -150,11 +136,11 @@ func _build_auth_tab() -> void:
 	var cp := PanelContainer.new()
 	var sb := StyleBoxFlat.new()
 	sb.bg_color = Color(0.10, 0.10, 0.10)
-	for side in [SIDE_LEFT,SIDE_RIGHT,SIDE_TOP,SIDE_BOTTOM]: sb.set_border_width(side, 1)
+	for side in [SIDE_LEFT, SIDE_RIGHT, SIDE_TOP, SIDE_BOTTOM]: sb.set_border_width(side, 1)
 	sb.border_color = Color(0.28, 0.28, 0.28)
-	for c in ["top_left","top_right","bottom_left","bottom_right"]: sb.set("corner_radius_"+c, 5)
-	sb.content_margin_left=12; sb.content_margin_right=12
-	sb.content_margin_top=3; sb.content_margin_bottom=3
+	for c in ["top_left", "top_right", "bottom_left", "bottom_right"]: sb.set("corner_radius_" + c, 5)
+	sb.content_margin_left = 12; sb.content_margin_right = 12
+	sb.content_margin_top = 3; sb.content_margin_bottom = 3
 	cp.add_theme_stylebox_override("panel", sb)
 	_view_wait.add_child(cp)
 
@@ -179,12 +165,10 @@ func _build_auth_tab() -> void:
 	_lbl_info.add_theme_font_size_override("font_size", 10)
 	_view_wait.add_child(_lbl_info)
 
-	# ── AUTHED ──
 	_view_authed = HBoxContainer.new()
 	_view_authed.add_theme_constant_override("separation", 14)
 	root.add_child(_view_authed)
 
-	# Keybindings summary
 	var kc := VBoxContainer.new(); kc.add_theme_constant_override("separation", 1)
 	_view_authed.add_child(kc)
 	var kt := Label.new(); kt.text = "Keybindings"
@@ -195,7 +179,6 @@ func _build_auth_tab() -> void:
 
 	_view_authed.add_child(_vsep())
 
-	# Model selector
 	var mc := VBoxContainer.new(); mc.add_theme_constant_override("separation", 2)
 	_view_authed.add_child(mc)
 	var ml := Label.new(); ml.text = "Model"
@@ -210,13 +193,12 @@ func _build_auth_tab() -> void:
 
 	_btn_refresh = Button.new(); _btn_refresh.text = "↺"; _btn_refresh.flat = true
 	_btn_refresh.tooltip_text = "Refresh model list"
-	_btn_refresh.pressed.connect(func(): _btn_refresh.disabled=true; _manager.fetch_models())
+	_btn_refresh.pressed.connect(func(): _btn_refresh.disabled = true; _manager.fetch_models())
 	mr.add_child(_btn_refresh)
 
 	var sp := Control.new(); sp.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	_view_authed.add_child(sp)
 
-	# User + sign out
 	var uc := VBoxContainer.new(); uc.add_theme_constant_override("separation", 2)
 	_view_authed.add_child(uc)
 	_lbl_user = Label.new(); _lbl_user.text = ""
@@ -225,20 +207,17 @@ func _build_auth_tab() -> void:
 	_btn_signout = Button.new(); _btn_signout.text = "Sign Out"; _btn_signout.flat = true
 	_btn_signout.pressed.connect(_on_signout_pressed); uc.add_child(_btn_signout)
 
-	# ── ERROR ──
 	_view_error = HBoxContainer.new()
 	_view_error.add_theme_constant_override("separation", 10)
 	root.add_child(_view_error)
 
 	_lbl_error = Label.new(); _lbl_error.text = ""
 	_lbl_error.add_theme_color_override("font_color", Color(1.0, 0.4, 0.4))
-	_lbl_error.autowrap_mode = TextServer.AUTOWRAP_WORD
+	_lbl_error.autowrap_mode = CopilotConsts.AUTOWRAP_WORD
 	_lbl_error.custom_minimum_size.x = 360; _view_error.add_child(_lbl_error)
 
 	_btn_retry = Button.new(); _btn_retry.text = "Try Again"
 	_btn_retry.pressed.connect(_on_signin_pressed); _view_error.add_child(_btn_retry)
-
-# ── Settings Tab ──────────────────────────────────────────────────────────────
 
 func _build_settings_tab() -> void:
 	var scroll := ScrollContainer.new()
@@ -252,7 +231,7 @@ func _build_settings_tab() -> void:
 	scroll.add_child(vbox)
 
 	var margin := MarginContainer.new()
-	for s in ["left","right","top","bottom"]:
+	for s in ["left", "right", "top", "bottom"]:
 		margin.add_theme_constant_override("margin_" + s, 8)
 	vbox.add_child(margin)
 
@@ -260,7 +239,6 @@ func _build_settings_tab() -> void:
 	inner.add_theme_constant_override("separation", 8)
 	margin.add_child(inner)
 
-	# ── Completion ───────────────────────────────────────────────────────────
 	inner.add_child(_section_label("Completion"))
 
 	_chk_auto_show = CheckBox.new()
@@ -272,7 +250,8 @@ func _build_settings_tab() -> void:
 	var deb_lbl := Label.new(); deb_lbl.text = "Trigger delay (seconds):"
 	deb_lbl.add_theme_font_size_override("font_size", 11); deb_row.add_child(deb_lbl)
 	_spin_debounce = SpinBox.new()
-	_spin_debounce.min_value = 0.2; _spin_debounce.max_value = 3.0
+	_spin_debounce.min_value = CopilotConsts.MIN_DEBOUNCE_DELAY
+	_spin_debounce.max_value = CopilotConsts.MAX_DEBOUNCE_DELAY
 	_spin_debounce.step = 0.05; _spin_debounce.custom_minimum_size.x = 80
 	deb_row.add_child(_spin_debounce)
 
@@ -285,7 +264,6 @@ func _build_settings_tab() -> void:
 
 	inner.add_child(_hsep())
 
-	# ── Session ──────────────────────────────────────────────────────────────
 	inner.add_child(_section_label("Session"))
 
 	_chk_auto_start = CheckBox.new()
@@ -298,7 +276,6 @@ func _build_settings_tab() -> void:
 
 	inner.add_child(_hsep())
 
-	# ── Keybindings info ─────────────────────────────────────────────────────
 	inner.add_child(_section_label("Keybindings"))
 
 	_lbl_keybinds = RichTextLabel.new()
@@ -314,7 +291,6 @@ func _build_settings_tab() -> void:
 
 	inner.add_child(_hsep())
 
-	# ── Debug ────────────────────────────────────────────────────────────────
 	inner.add_child(_section_label("Debug"))
 
 	_btn_log = Button.new(); _btn_log.text = "📋  View Relay Log"
@@ -323,14 +299,11 @@ func _build_settings_tab() -> void:
 
 	inner.add_child(_hsep())
 
-	# ── Save button ──────────────────────────────────────────────────────────
 	_btn_save = Button.new(); _btn_save.text = "  Save Settings  "
 	_btn_save.pressed.connect(_on_save_settings)
 	var save_row := HBoxContainer.new()
 	save_row.add_child(_btn_save)
 	inner.add_child(save_row)
-
-# ── UI helpers ────────────────────────────────────────────────────────────────
 
 func _vsep() -> VSeparator:
 	return VSeparator.new()
@@ -344,15 +317,13 @@ func _section_label(text: String) -> Label:
 	lbl.add_theme_color_override("font_color", Color(0.55, 0.75, 0.55))
 	return lbl
 
-# ── Auth state machine ────────────────────────────────────────────────────────
-
 func _set_auth_state(s: AuthState) -> void:
 	_auth_state = s
 	if not is_instance_valid(_view_out): return
-	_view_out.visible    = (s == AuthState.SIGNED_OUT)
-	_view_wait.visible   = (s == AuthState.WAITING)
+	_view_out.visible = (s == AuthState.SIGNED_OUT)
+	_view_wait.visible = (s == AuthState.WAITING)
 	_view_authed.visible = (s == AuthState.AUTHED)
-	_view_error.visible  = (s == AuthState.ERROR)
+	_view_error.visible = (s == AuthState.ERROR)
 	match s:
 		AuthState.SIGNED_OUT:
 			_lbl_status.text = "Not signed in"
@@ -374,8 +345,6 @@ func _set_auth_state(s: AuthState) -> void:
 			_lbl_status.add_theme_color_override("font_color", Color(1.0, 0.4, 0.4))
 			_spin_timer.stop()
 
-# ── Model helpers ─────────────────────────────────────────────────────────────
-
 func _populate_models() -> void:
 	var popup := _btn_model.get_popup()
 	popup.clear()
@@ -384,7 +353,7 @@ func _populate_models() -> void:
 	for i in range(_models_list.size()):
 		var m: Dictionary = _models_list[i]
 		var label: String = m.get("modelName", m.get("name", m.get("id", "?")))
-		var id:    String = m.get("id", "")
+		var id: String = m.get("id", "")
 		popup.add_item(label, i + 1)
 		popup.set_item_checked(i + 1, _manager.get_current_model() == id)
 
@@ -395,29 +364,25 @@ func _model_display(id: String) -> String:
 			return m.get("modelName", m.get("name", id))
 	return id
 
-# ── Settings load/save ────────────────────────────────────────────────────────
-
 func _load_settings_to_ui() -> void:
 	if not is_instance_valid(_chk_auto_show): return
-	_chk_auto_show.button_pressed  = _settings.auto_show_completions
+	_chk_auto_show.button_pressed = _settings.auto_show_completions
 	_chk_auto_start.button_pressed = _settings.auto_start
-	_chk_remember.button_pressed   = _settings.remember_session
-	_spin_debounce.value           = _settings.debounce_delay
-	_color_ghost.color             = _settings.ghost_color
+	_chk_remember.button_pressed = _settings.remember_session
+	_spin_debounce.value = _settings.debounce_delay
+	_color_ghost.color = _settings.ghost_color
 
 func _on_save_settings() -> void:
 	_settings.auto_show_completions = _chk_auto_show.button_pressed
-	_settings.auto_start            = _chk_auto_start.button_pressed
-	_settings.remember_session      = _chk_remember.button_pressed
-	_settings.debounce_delay        = _spin_debounce.value
-	_settings.ghost_color           = _color_ghost.color
+	_settings.auto_start = _chk_auto_start.button_pressed
+	_settings.remember_session = _chk_remember.button_pressed
+	_settings.debounce_delay = _spin_debounce.value
+	_settings.ghost_color = _color_ghost.color
 	_settings.save_settings()
 	_btn_save.text = "✓  Saved!"
 	get_tree().create_timer(1.5).timeout.connect(func():
 		if is_instance_valid(_btn_save): _btn_save.text = "  Save Settings  "
 	)
-
-# ── Signal handlers ───────────────────────────────────────────────────────────
 
 func _on_signin_pressed() -> void:
 	_btn_signin.disabled = true; _btn_retry.disabled = true
@@ -470,7 +435,6 @@ func _on_models(models: Array) -> void:
 	_models_list = models
 	_btn_refresh.disabled = false
 	_populate_models()
-	# Restore saved model
 	if not _settings.saved_model_id.is_empty():
 		_manager.set_model(_settings.saved_model_id)
 		_btn_model.text = _model_display(_settings.saved_model_id)
@@ -482,20 +446,19 @@ func _on_model_selected(idx: int) -> void:
 		model_id = m.get("id", "")
 	_manager.set_model(model_id)
 	_btn_model.text = _model_display(model_id)
-	_settings.set_model(model_id)   # persist
+	_settings.set_model(model_id)
 	_populate_models()
 
 func _on_view_log() -> void:
 	var log_text: String = _manager.get_relay_log()
-	# Show in a popup
 	var dlg := AcceptDialog.new()
 	dlg.title = "Copilot Relay Log"
-	dlg.size  = Vector2(700, 400)
+	dlg.size = Vector2(700, 400)
 	var rt := RichTextLabel.new()
-	rt.text              = log_text
-	rt.fit_content       = false
-	rt.scroll_following  = true
-	rt.size_flags_vertical   = Control.SIZE_EXPAND_FILL
+	rt.text = log_text
+	rt.fit_content = false
+	rt.scroll_following = true
+	rt.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	rt.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	dlg.add_child(rt)
 	add_child(dlg)

--- a/addons/github_copilot/copilot_settings.gd
+++ b/addons/github_copilot/copilot_settings.gd
@@ -3,20 +3,17 @@
 ## Saved to user://copilot_settings.cfg
 extends RefCounted
 
-const SETTINGS_PATH := "user://copilot_settings.cfg"
+const CopilotConsts := preload("res://addons/github_copilot/consts.gd")
 
-# Completion
 var auto_show_completions: bool = true
-var debounce_delay:        float = 0.65   # seconds
-var accept_key:            int   = KEY_TAB
-var dismiss_key:           int   = KEY_ESCAPE
-var ghost_color:           Color = Color(0.52, 0.52, 0.52, 0.65)
+var debounce_delay: float = CopilotConsts.DEFAULT_DEBOUNCE_DELAY
+var accept_key: int = KEY_TAB
+var dismiss_key: int = KEY_ESCAPE
+var ghost_color: Color = CopilotConsts.DEFAULT_GHOST_COLOR
 
-# Session
-var auto_start:      bool   = true    # reconnect LSP on Godot restart
-var saved_model_id:  String = ""      # last used model
+var auto_start: bool = true
+var saved_model_id: String = ""
 
-# Auth token cache (stored separately, read-only here)
 var remember_session: bool = true
 
 signal settings_changed()
@@ -26,24 +23,24 @@ func _init() -> void:
 
 func load_settings() -> void:
 	var cfg := ConfigFile.new()
-	if cfg.load(SETTINGS_PATH) != OK:
+	if cfg.load(CopilotConsts.SETTINGS_FILE) != OK:
 		return
-	auto_show_completions = cfg.get_value("completion", "auto_show",  true)
-	debounce_delay        = cfg.get_value("completion", "debounce",   0.65)
-	ghost_color           = cfg.get_value("completion", "ghost_color", Color(0.52, 0.52, 0.52, 0.65))
-	auto_start            = cfg.get_value("session",    "auto_start", true)
-	saved_model_id        = cfg.get_value("session",    "model_id",   "")
-	remember_session      = cfg.get_value("session",    "remember",   true)
+	auto_show_completions = cfg.get_value("completion", "auto_show", true)
+	debounce_delay = cfg.get_value("completion", "debounce", CopilotConsts.DEFAULT_DEBOUNCE_DELAY)
+	ghost_color = cfg.get_value("completion", "ghost_color", CopilotConsts.DEFAULT_GHOST_COLOR)
+	auto_start = cfg.get_value("session", "auto_start", true)
+	saved_model_id = cfg.get_value("session", "model_id", "")
+	remember_session = cfg.get_value("session", "remember", true)
 
 func save_settings() -> void:
 	var cfg := ConfigFile.new()
-	cfg.set_value("completion", "auto_show",   auto_show_completions)
-	cfg.set_value("completion", "debounce",    debounce_delay)
+	cfg.set_value("completion", "auto_show", auto_show_completions)
+	cfg.set_value("completion", "debounce", debounce_delay)
 	cfg.set_value("completion", "ghost_color", ghost_color)
-	cfg.set_value("session",    "auto_start",  auto_start)
-	cfg.set_value("session",    "model_id",    saved_model_id)
-	cfg.set_value("session",    "remember",    remember_session)
-	cfg.save(SETTINGS_PATH)
+	cfg.set_value("session", "auto_start", auto_start)
+	cfg.set_value("session", "model_id", saved_model_id)
+	cfg.set_value("session", "remember", remember_session)
+	cfg.save(CopilotConsts.SETTINGS_FILE)
 	settings_changed.emit()
 
 func set_model(id: String) -> void:

--- a/addons/github_copilot/plugin.gd
+++ b/addons/github_copilot/plugin.gd
@@ -1,25 +1,22 @@
 @tool
 extends EditorPlugin
 
-const CopilotManager  = preload("res://addons/github_copilot/copilot_manager.gd")
-const CopilotPanel    = preload("res://addons/github_copilot/copilot_panel.gd")
-const CopilotOverlay  = preload("res://addons/github_copilot/copilot_overlay.gd")
-const CopilotSettings = preload("res://addons/github_copilot/copilot_settings.gd")
+const CopilotConsts := preload("res://addons/github_copilot/consts.gd")
+const CopilotManager := preload("res://addons/github_copilot/copilot_manager.gd")
+const CopilotPanel := preload("res://addons/github_copilot/copilot_panel.gd")
+const CopilotOverlay := preload("res://addons/github_copilot/copilot_overlay.gd")
+const CopilotSettings := preload("res://addons/github_copilot/copilot_settings.gd")
 
-var manager:  CopilotManager
-var panel:    CopilotPanel
+var manager: CopilotManager
+var panel: CopilotPanel
 var settings: CopilotSettings
-
-# Overlay is a RefCounted (not a Node), managed per active editor
 var overlay: CopilotOverlay = null
 
-var script_editor:    ScriptEditor = null
-var current_code_edit: CodeEdit    = null
-var current_uri:      String       = ""
+var script_editor: ScriptEditor = null
+var current_code_edit: CodeEdit = null
+var current_uri: String = ""
 
 var debounce: Timer = null
-
-# ── Lifecycle ─────────────────────────────────────────────────────────────────
 
 func _enter_tree() -> void:
 	settings = CopilotSettings.new()
@@ -29,14 +26,13 @@ func _enter_tree() -> void:
 	add_child(manager)
 
 	panel = CopilotPanel.new(manager, settings)
-	add_control_to_bottom_panel(panel, "Copilot")
+	add_control_to_bottom_panel(panel, CopilotConsts.PLUGIN_NAME)
 
 	debounce = Timer.new()
-	debounce.name     = "CopilotDebounce"
+	debounce.name = "CopilotDebounce"
 	debounce.one_shot = true
 	debounce.timeout.connect(_request_completion)
 	add_child(debounce)
-	# Apply saved delay
 	debounce.wait_time = settings.debounce_delay
 	settings.settings_changed.connect(func():
 		debounce.wait_time = settings.debounce_delay
@@ -48,25 +44,19 @@ func _enter_tree() -> void:
 
 	_hook_editor()
 
-	# Auto-start: if setting enabled, start LSP immediately
 	if settings.auto_start:
-		await get_tree().process_frame   # let panel finish _ready
+		await get_tree().process_frame
 		manager.start_sign_in()
 
 func _exit_tree() -> void:
-	# Unhook first so no callbacks fire during teardown
 	_unhook_editor()
 
 	if is_instance_valid(panel):
 		remove_control_from_bottom_panel(panel)
 		panel.queue_free()
 
-	# manager._exit_tree / _shutdown called automatically when removed
-	# but we trigger it explicitly to be safe
 	if is_instance_valid(manager):
 		manager._shutdown()
-
-# ── Editor wiring ─────────────────────────────────────────────────────────────
 
 func _on_script_changed(_script) -> void:
 	_unhook_editor()
@@ -81,15 +71,14 @@ func _hook_editor() -> void:
 
 	current_code_edit = ce
 
-	# ── Fix: only connect if NOT already connected ──
 	if not current_code_edit.text_changed.is_connected(_on_text_changed):
 		current_code_edit.text_changed.connect(_on_text_changed)
 
-	# Create fresh overlay
 	if overlay:
 		overlay.hide_suggestion()
 		overlay = null
 	overlay = CopilotOverlay.new()
+	overlay.set_ghost_color(settings.ghost_color)
 
 	var script := script_editor.get_current_script() if script_editor else null
 	if script:
@@ -97,7 +86,6 @@ func _hook_editor() -> void:
 		manager.notify_document_focus(current_uri)
 
 func _unhook_editor() -> void:
-	# Dismiss any active suggestion
 	if overlay:
 		overlay.hide_suggestion()
 		overlay = null
@@ -107,7 +95,7 @@ func _unhook_editor() -> void:
 			current_code_edit.text_changed.disconnect(_on_text_changed)
 
 	current_code_edit = null
-	current_uri       = ""
+	current_uri = ""
 
 func _find_by_class(node: Node, cls: String) -> Node:
 	for child in node.get_children():
@@ -115,8 +103,6 @@ func _find_by_class(node: Node, cls: String) -> Node:
 		var found := _find_by_class(child, cls)
 		if found: return found
 	return null
-
-# ── Completion flow ───────────────────────────────────────────────────────────
 
 func _on_text_changed() -> void:
 	if overlay:
@@ -141,8 +127,6 @@ func _on_suggestion_received(text: String) -> void:
 	if text.strip_edges().is_empty(): return
 	overlay.show_suggestion(text, current_code_edit)
 
-# ── Input ─────────────────────────────────────────────────────────────────────
-
 func _input(event: InputEvent) -> void:
 	if not overlay or not overlay.has_suggestion(): return
 	if not (event is InputEventKey) or not event.pressed: return
@@ -157,7 +141,6 @@ func _input(event: InputEvent) -> void:
 			overlay.hide_suggestion()
 			get_viewport().set_input_as_handled()
 
-		# Cursor movement: dismiss without consuming
 		KEY_LEFT, KEY_RIGHT, KEY_UP, KEY_DOWN, \
 		KEY_HOME, KEY_END, KEY_PAGEUP, KEY_PAGEDOWN:
 			overlay.hide_suggestion()


### PR DESCRIPTION
## Problem
When Godot is launched from a desktop entry (not a terminal), the relay process fails to find `node` because PATH doesn't include version managers like NVM/fnm/volta/asdf. (Issue in Linux-like Systems)

## Solution
- Pass Godot's binary directory to the relay so it prepends it to PATH
- Enhance `_which()` to fall back to login+interactive shell (runs profile scripts) and scan common install locations (`~/.volta/bin`, `~/.asdf/shims`, `~/.local/bin`, NVM/fnm versions)

## Testing
Tested by launching Godot from desktop entry with NVM/fnm installed in Ubuntu 24 LTS
